### PR TITLE
use a custom create_documenter function

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -37,9 +37,15 @@ becomes:
 
 Callable accessors can be documented, too:
 
+.. warning::
+
+    This feature is only fully supported from sphinx version 3.1 onwards. On
+    earlier versions, the summary will claim this is a alias of the
+    accessor class.
+
 .. literalinclude:: examples.rst
    :language: rst
-   :lines: 46-50
+   :lines: 52-56
 
 becomes:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx>=3.1
 sphinx_rtd_theme
 packaging
 importlib-metadata; python_version < "3.8"

--- a/sphinx_autosummary_accessors/autosummary.py
+++ b/sphinx_autosummary_accessors/autosummary.py
@@ -47,7 +47,7 @@ def create_documenter_from_template(autosummary, app, obj, parent, full_name):
 
     documenter_name, real_name = extract_documenter(rendered)
     doccls = app.registry.documenters.get(documenter_name)
-    documenter = doccls(autosummary.bridge, full_name)
+    documenter = doccls(autosummary.bridge, real_name)
 
     return documenter
 

--- a/sphinx_autosummary_accessors/autosummary.py
+++ b/sphinx_autosummary_accessors/autosummary.py
@@ -3,6 +3,10 @@ import re
 from sphinx.ext import autosummary
 from sphinx.ext.autosummary import Autosummary, __, generate
 
+original_create_documenter = getattr(
+    Autosummary, "create_documenter", lambda *args: None
+)
+
 
 def extract_documenter(content):
     directives_re = re.compile(r"^\.\. ([^:]+):: (.+)$", re.MULTILINE)
@@ -15,34 +19,41 @@ def extract_documenter(content):
     return directive_name, "::".join([modname, name])
 
 
+def create_documenter_from_template(autosummary, app, obj, parent, full_name):
+    real_name = ".".join(full_name.split("::"))
+
+    options = autosummary.options.copy()
+    template_name = options.pop("template")
+    if template_name is None:
+        return original_create_documenter(autosummary, app, obj, parent, full_name)
+
+    options.pop("toctree")
+    options["imported_members"] = options.get("imported_members", False)
+    options["recursive"] = options.get("recursive", False)
+
+    context = {}
+    context.update(app.config.autosummary_context)
+
+    rendered = generate.generate_autosummary_content(
+        real_name,
+        obj,
+        parent,
+        template=generate.AutosummaryRenderer(app),
+        template_name=template_name,
+        app=app,
+        context=context,
+        **options,
+    )
+
+    documenter_name, real_name = extract_documenter(rendered)
+    doccls = app.registry.documenters.get(documenter_name)
+    documenter = doccls(autosummary.bridge, full_name)
+
+    return documenter
+
+
 class CustomAutosummary(Autosummary):
-    def get_documenter_from_template(self, name, obj, parent, options):
-        options = options.copy()
-        options.pop("toctree")
-        template_name = options.pop("template")
-        options["imported_members"] = options.get("imported_members", False)
-        options["recursive"] = options.get("recursive", False)
-
-        app = self.env.app
-
-        context = {}
-        context.update(app.config.autosummary_context)
-
-        rendered = generate.generate_autosummary_content(
-            name,
-            obj,
-            parent,
-            template=generate.AutosummaryRenderer(app),
-            template_name=template_name,
-            app=app,
-            context=context,
-            **options,
-        )
-
-        documenter_name, real_name = extract_documenter(rendered)
-        documenter = app.registry.documenters.get(documenter_name)
-
-        return documenter, real_name
+    create_documenter = create_documenter_from_template
 
     def get_items(self, names):
         """Try to import the given names, and return a list of
@@ -83,14 +94,8 @@ class CustomAutosummary(Autosummary):
             # NB. using full_name here is important, since Documenters
             #     handle module prefixes slightly differently
 
-            if "template" in self.options:
-                doccls, full_name = self.get_documenter_from_template(
-                    real_name, obj, parent, self.options
-                )
-            else:
-                doccls = autosummary.get_documenter(self.env.app, obj, parent)
+            documenter = self.create_documenter(self.env.app, obj, parent, full_name)
 
-            documenter = doccls(self.bridge, full_name)
             if not documenter.parse_name():
                 autosummary.logger.warning(
                     __("failed to parse name %s"),


### PR DESCRIPTION
~sphinx-doc/sphinx#8038 explores the option to support registering custom `get_documenter` functions.~ `sphinx` recently got support for overriding `get_documenter` (via the `Autosummary.create_documenter` method).

This can be used to make sure the accessor documenters are chosen if the corresponding template was specified, making it possible to remove / avoid the ugly hack from #6.

- [x] closes #7