### PR TITLE
avoid deprecated functions

### DIFF
--- a/sphinx_autosummary_accessors/documenters.py
+++ b/sphinx_autosummary_accessors/documenters.py
@@ -1,6 +1,5 @@
 import sphinx
 from sphinx.ext.autodoc import AttributeDocumenter, Documenter, MethodDocumenter
-from sphinx.util import rpartition
 
 
 class AccessorDocumenter(MethodDocumenter):
@@ -55,8 +54,8 @@ class AccessorLevelDocumenter(Documenter):
             # HACK: this is added in comparison to ClassLevelDocumenter
             # mod_cls still exists of class.accessor, so an extra
             # rpartition is needed
-            modname, accessor = rpartition(mod_cls, ".")
-            modname, cls = rpartition(modname, ".")
+            modname, _, accessor = mod_cls.rpartition(".")
+            modname, _, cls = modname.rpartition(".")
             parents = [cls, accessor]
             # if the module name is still missing, get it like above
             if not modname:


### PR DESCRIPTION
`sphinx.util.rpartition` has been deprecated in favor of `str.rpartition`. The only difference is that `str.rpartition` will also return the separator.