### PR TITLE
fix autosummary blocks without a template

### DIFF
--- a/docs/example.py
+++ b/docs/example.py
@@ -14,6 +14,8 @@ class CachedAccessor:
 
 
 class Example:
+    """ test class """
+
     def __init__(self, data):
         self._data = data
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -14,12 +14,19 @@ Consider the accessor class:
    :language: python
    :lines: 30-
 
+for a class named :py:class:`Example`:
+
+.. autosummary::
+   :toctree: generated/
+
+   Example
+
 Documenting attributes and methods can be done with the
 ``accessor_attribute.rst`` and ``accessor_method.rst`` templates:
 
 .. literalinclude:: examples.rst
    :language: rst
-   :lines: 26-36
+   :lines: 33-43
 
 becomes:
 
@@ -45,7 +52,7 @@ Callable accessors can be documented, too:
 
 .. literalinclude:: examples.rst
    :language: rst
-   :lines: 52-56
+   :lines: 59-63
 
 becomes:
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -4,6 +4,8 @@ What's new
 v0.2 (unreleased)
 -----------------
 - fix autosummary blocks without a template option (:pull:`16`)
+- fix create_documenter on sphinx<3.2 (:pull:`17`)
+- add a documention url to the package description on PyPI (:pull:`18`)
 
 
 v0.1 (2020-08-07)

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -3,6 +3,7 @@ What's new
 
 v0.2 (unreleased)
 -----------------
+- fix autosummary blocks without a template option (:pull:`16`)
 
 
 v0.1 (2020-08-07)

--- a/sphinx_autosummary_accessors/autosummary.py
+++ b/sphinx_autosummary_accessors/autosummary.py
@@ -23,11 +23,11 @@ def create_documenter_from_template(autosummary, app, obj, parent, full_name):
     real_name = ".".join(full_name.split("::"))
 
     options = autosummary.options.copy()
-    template_name = options.pop("template")
+    template_name = options.pop("template", None)
     if template_name is None:
         return original_create_documenter(autosummary, app, obj, parent, full_name)
 
-    options.pop("toctree")
+    options.pop("toctree", None)
     options["imported_members"] = options.get("imported_members", False)
     options["recursive"] = options.get("recursive", False)
 


### PR DESCRIPTION
These failed because `dict.pop` will raise a `KeyError` if the key doesn't exist and no default was passed (unlike `dict.get`, which defaults to `None`).