### PR TITLE
don't fail on unused options

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -3,7 +3,7 @@ What's new
 
 v0.3 (*unreleased*)
 -------------------
-- don't break on unknown parameters (:pull:`38`)
+- don't fail on options which are not parameters to the render function (:pull:`38`)
 
 v0.2 (2021-03-06)
 -----------------

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -3,7 +3,7 @@ What's new
 
 v0.3 (*unreleased*)
 -------------------
-
+- don't break on unknown parameters (:pull:`38`)
 
 v0.2 (2021-03-06)
 -----------------

--- a/sphinx_autosummary_accessors/autosummary.py
+++ b/sphinx_autosummary_accessors/autosummary.py
@@ -25,8 +25,8 @@ def create_documenter_from_template(autosummary, app, obj, parent, full_name):
     if template_name is None:
         return original_create_documenter(autosummary, app, obj, parent, full_name)
 
-    options["imported_members"] = options.get("imported_members", False)
-    options["recursive"] = options.get("recursive", False)
+    imported_members = options.get("imported_members", False)
+    recursive = options.get("recursive", False)
 
     context = {}
     context.update(app.config.autosummary_context)
@@ -39,7 +39,8 @@ def create_documenter_from_template(autosummary, app, obj, parent, full_name):
         template_name=template_name,
         app=app,
         context=context,
-        **options,
+        imported_members=imported_members,
+        recursive=recursive,
     )
 
     documenter_name, real_name = extract_documenter(rendered)

--- a/sphinx_autosummary_accessors/autosummary.py
+++ b/sphinx_autosummary_accessors/autosummary.py
@@ -20,12 +20,11 @@ def extract_documenter(content):
 def create_documenter_from_template(autosummary, app, obj, parent, full_name):
     real_name = ".".join(full_name.split("::"))
 
-    options = autosummary.options.copy()
-    template_name = options.pop("template", None)
+    options = autosummary.options
+    template_name = options.get("template", None)
     if template_name is None:
         return original_create_documenter(autosummary, app, obj, parent, full_name)
 
-    options.pop("toctree", None)
     options["imported_members"] = options.get("imported_members", False)
     options["recursive"] = options.get("recursive", False)
 


### PR DESCRIPTION
Up until now, the code would pass options to the rendering function using `**options`. This breaks as soon as we want to pass an option which is not also a parameter.

- [x] closes #36
- [x] updated `whats-new.rst`