### PR TITLE
manually autoupdate the `pre-commit` ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,8 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
-  - repo: https://github.com/python/black
-    rev: 22.1.0
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8


### PR DESCRIPTION
`black` is broken due to a update of `click`