### PR TITLE
compatibility with `extlinks` in `sphinx>=6.0`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,8 +93,8 @@ autosummary_generate = True
 # extlinks
 base_url = "https://github.com/xarray-contrib/sphinx-autosummary-accessors"
 extlinks = {
-    "issue": (f"{base_url}/issues/%s", "GH"),
-    "pull": (f"{base_url}/pull/%s", "PR"),
+    "issue": (f"{base_url}/issues/%s", "GH %s"),
+    "pull": (f"{base_url}/pull/%s", "PR %s"),
 }
 
 # napoleon


### PR DESCRIPTION
Apparently, `extlinks` requires one `%s` in the link texts now.