### PR TITLE
drop `python=3.7`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           python -m pip install "sphinx==${{matrix.sphinx-version}}"
           if [[ "${{matrix.sphinx-version}}" < "4.0" ]]; then
-              python -m pip install "jinja2<3.1"
+              python -m pip install "jinja2<3.1" "docutils<0.18"
           fi
 
       - name: install other dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         sphinx-version: ['3.5', '4.5', '5.0', '5.1', '5.2', '5.3']
         exclude:
           # sphinx versions incompatible with python 3.10

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -6,6 +6,7 @@ What's new
 - add official support for python 3.11 and `sphinx>=5.0` (:pull:`87`)
 - change the policy to only actively support the last minor release of older major versions of `sphinx`.
   Currently supported versions are now: `3.5`, `4.5`, `sphinx>=5.0` (:pull:`87`).
+- drop support for `python=3.7` (:pull:`93`)
 
 2022.04.0 (2022-04-04)
 ----------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ project_urls =
 packages = find:
 python_requires = >=3.8
 install_requires =
-    sphinx>=3.3
+    sphinx>=3.5
 
 [options.package_data]
 sphinx_autosummary_accessors = templates/autosummary/*.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,9 @@ project_urls =
 
 [options]
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     sphinx>=3.3
-    importlib-metadata; python_version < "3.8"
 
 [options.package_data]
 sphinx_autosummary_accessors = templates/autosummary/*.rst


### PR DESCRIPTION
python 3.7 is reaching its end of life pretty soon and the scientific ecosystem (the main target of this package) has dropped it quite some time ago, so we can safely do that here, as well.