### PR TITLE
test compatibility with `sphinx>=6.0` and `sphinx=6.1`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        sphinx-version: ['3.5', '4.5', '5.0', '5.1', '5.2', '5.3']
+        sphinx-version: ['3.5', '4.5', '5.0', '5.1', '5.2', '5.3', '6.0', '6.1']
         exclude:
           # sphinx versions incompatible with python 3.10
           - python-version: "3.10"

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -4,8 +4,9 @@ What's new
 (*unreleased*)
 --------------
 - add official support for python 3.11 and `sphinx>=5.0` (:pull:`87`)
-- change the policy to only actively support the last minor release of older major versions of `sphinx`.
-  Currently supported versions are now: `3.5`, `4.5`, `sphinx>=5.0` (:pull:`87`, :pull:`100`).
+- change the policy to only actively support the last minor release of older major
+  versions of `sphinx`.  Currently supported versions are now: `3.5`, `4.5`, and all minor
+  versions of `5`, and `6` (:pull:`87`, :pull:`100`).
 - switch to a `pyproject.toml`-based build (:pull:`99`)
 - drop support for `python=3.7` (:pull:`93`)
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -5,7 +5,8 @@ What's new
 --------------
 - add official support for python 3.11 and `sphinx>=5.0` (:pull:`87`)
 - change the policy to only actively support the last minor release of older major versions of `sphinx`.
-  Currently supported versions are now: `3.5`, `4.5`, `sphinx>=5.0` (:pull:`87`).
+  Currently supported versions are now: `3.5`, `4.5`, `sphinx>=5.0` (:pull:`87`, :pull:`100`).
+- switch to a `pyproject.toml`-based build (:pull:`99`)
 - drop support for `python=3.7` (:pull:`93`)
 
 2022.04.0 (2022-04-04)


### PR DESCRIPTION
We should already be compatible since the nightly CI doesn't fail, but this makes debugging a bit easier.