### PR TITLE
Fix callable accessor names

### DIFF
--- a/sphinx_autosummary_accessors/documenters.py
+++ b/sphinx_autosummary_accessors/documenters.py
@@ -108,4 +108,4 @@ class AccessorCallableDocumenter(AccessorLevelDocumenter, MethodDocumenter):
     priority = 0.5
 
     def format_name(self):
-        return MethodDocumenter.format_name(self).rstrip(".__call__")
+        return MethodDocumenter.format_name(self).removesuffix(".__call__")


### PR DESCRIPTION
Currently, the extension will break the name of callable accessors if it ends with `c`, `a`, or `l`, since `.__call__` is removed with `str.rstrip`. This PR fixes this by replacing it with `str.removesuffix`.
