### PR TITLE
upgrade the rtd config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,3 +18,4 @@ python:
 
 sphinx:
   fail_on_warning: true
+  configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ formats: []
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.12"
   jobs:
     post_checkout:
       - (git --no-pager log --pretty="tformat:%s" -1 | grep -vqF "[skip-rtd]") || exit 183

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 packaging
-sphinx>=3.1
+sphinx>=6
 sphinx_rtd_theme


### PR DESCRIPTION
Since a little while ago, `sphinx` requires the use of the `sphinx.configuration` key.