### PR TITLE
drop support for very old versions of `sphinx`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,12 +16,6 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
         sphinx-version: ["5.3", "6.0", "6.1"]
-        exclude:
-          # sphinx versions incompatible with python 3.10
-          - python-version: "3.10"
-            sphinx-version: "3.5"
-          - python-version: "3.11"
-            sphinx-version: "3.5"
 
     steps:
       - name: checkout the repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-        sphinx-version: ["3.5", "4.5", "5.0", "5.1", "5.2", "5.3", "6.0", "6.1"]
+        sphinx-version: ["5.3", "6.0", "6.1"]
         exclude:
           # sphinx versions incompatible with python 3.10
           - python-version: "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.rst"
 requires-python = ">=3.9"
 dependencies = [
-  "sphinx >= 3.5",
+  "sphinx >= 5.3",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
We now require `sphinx>=5.3`.