### PR TITLE
stop testing on python 3.10 and 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.12", "3.13"]
         sphinx-version: ["5.3", "6.0", "6.1"]
 
     steps:


### PR DESCRIPTION
(this avoids testing on python versions with little benefit)