### PR TITLE
FIX adapt code for sphinx 8.2.0 app -> registry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.12", "3.13"]
-        sphinx-version: ["5.3", "6.2", "7.3", "7.4", "8.0", "8.1"]
+        sphinx-version: ["5.3", "6.2", "7.3", "7.4", "8.0", "8.1", "8.2"]
         exclude:
           # sphinx>=8 requires at least python 3.10
           - python-version: "3.9"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ jobs:
             sphinx-version: "8.0"
           - python-version: "3.9"
             sphinx-version: "8.1"
+          - python-version: "3.9"
+            sphinx-version: "8.2"
           # sphinx<6.2 uses imghdr, which was removed in python 3.13
           - python-version: "3.13"
             sphinx-version: "5.3"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 packaging
-sphinx>=6,<8.2
+sphinx>=6
 sphinx_rtd_theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 ]
 dependencies = [
   "sphinx >= 5.3",
+  "packaging",
 ]
 dynamic = ["version"]
 

--- a/sphinx_autosummary_accessors/autosummary.py
+++ b/sphinx_autosummary_accessors/autosummary.py
@@ -51,7 +51,7 @@ if version.parse(sphinx.__version__) >= version.Version("8.2.0"):
             imported_members=imported_members,
             recursive=recursive,
             registry=registry,
-            events=autosummary.events,
+            events=autosummary.env.events,
             config=autosummary.env.config,
         )
 

--- a/sphinx_autosummary_accessors/autosummary.py
+++ b/sphinx_autosummary_accessors/autosummary.py
@@ -51,6 +51,8 @@ if version.parse(sphinx.__version__) >= version.Version("8.2.0"):
             imported_members=imported_members,
             recursive=recursive,
             registry=registry,
+            events=autosummary.events,
+            config=autosummary.env.config,
         )
 
         documenter_name, real_name = extract_documenter(rendered)

--- a/sphinx_autosummary_accessors/autosummary.py
+++ b/sphinx_autosummary_accessors/autosummary.py
@@ -39,13 +39,13 @@ if version.parse(sphinx.__version__) >= version.Version("8.2.0"):
         recursive = options.get("recursive", False)
 
         context = {}
-        context.update(autosummary.app.config.autosummary_context)
+        context.update(autosummary.env.config.autosummary_context)
 
         rendered = generate.generate_autosummary_content(
             real_name,
             obj,
             parent,
-            template=generate.AutosummaryRenderer(autosummary.app),
+            template=generate.AutosummaryRenderer(autosummary.env.app),
             template_name=template_name,
             context=context,
             imported_members=imported_members,

--- a/sphinx_autosummary_accessors/autosummary.py
+++ b/sphinx_autosummary_accessors/autosummary.py
@@ -1,5 +1,7 @@
 import re
 
+import sphinx
+from packaging import version
 from sphinx.ext.autosummary import Autosummary, generate
 
 from sphinx_autosummary_accessors.templates import known_templates
@@ -19,36 +21,74 @@ def extract_documenter(content):
     return directive_name, "::".join([modname, name])
 
 
-def create_documenter_from_template(autosummary, obj, parent, full_name, *, registry):
-    real_name = ".".join(full_name.split("::"))
+if version.parse(sphinx.__version__) >= version.Version("8.2.0"):
 
-    options = autosummary.options
-    template_name = options.get("template", None)
-    if template_name is None or template_name not in known_templates:
-        return original_create_documenter(
-            autosummary, obj, parent, full_name, registry=registry
+    def create_documenter_from_template(
+        autosummary, obj, parent, full_name, *, registry
+    ):
+        real_name = ".".join(full_name.split("::"))
+
+        options = autosummary.options
+        template_name = options.get("template", None)
+        if template_name is None or template_name not in known_templates:
+            return original_create_documenter(
+                autosummary, obj, parent, full_name, registry=registry
+            )
+
+        imported_members = options.get("imported_members", False)
+        recursive = options.get("recursive", False)
+
+        context = {}
+        context.update(autosummary.app.config.autosummary_context)
+
+        rendered = generate.generate_autosummary_content(
+            real_name,
+            obj,
+            parent,
+            template=generate.AutosummaryRenderer(autosummary.app),
+            template_name=template_name,
+            context=context,
+            imported_members=imported_members,
+            recursive=recursive,
+            registry=registry,
         )
 
-    imported_members = options.get("imported_members", False)
-    recursive = options.get("recursive", False)
+        documenter_name, real_name = extract_documenter(rendered)
+        doccls = registry.documenters.get(documenter_name)
+        documenter = doccls(autosummary.bridge, real_name)
 
-    context = {}
-    context.update(autosummary.app.config.autosummary_context)
+        return documenter
 
-    rendered = generate.generate_autosummary_content(
-        real_name,
-        obj,
-        parent,
-        template=generate.AutosummaryRenderer(autosummary.app),
-        template_name=template_name,
-        context=context,
-        imported_members=imported_members,
-        recursive=recursive,
-        registry=registry,
-    )
+else:
 
-    documenter_name, real_name = extract_documenter(rendered)
-    doccls = registry.documenters.get(documenter_name)
-    documenter = doccls(autosummary.bridge, real_name)
+    def create_documenter_from_template(autosummary, app, obj, parent, full_name):
+        real_name = ".".join(full_name.split("::"))
 
-    return documenter
+        options = autosummary.options
+        template_name = options.get("template", None)
+        if template_name is None or template_name not in known_templates:
+            return original_create_documenter(autosummary, app, obj, parent, full_name)
+
+        imported_members = options.get("imported_members", False)
+        recursive = options.get("recursive", False)
+
+        context = {}
+        context.update(app.config.autosummary_context)
+
+        rendered = generate.generate_autosummary_content(
+            real_name,
+            obj,
+            parent,
+            template=generate.AutosummaryRenderer(app),
+            template_name=template_name,
+            app=app,
+            context=context,
+            imported_members=imported_members,
+            recursive=recursive,
+        )
+
+        documenter_name, real_name = extract_documenter(rendered)
+        doccls = app.registry.documenters.get(documenter_name)
+        documenter = doccls(autosummary.bridge, real_name)
+
+        return documenter


### PR DESCRIPTION
Trying to solve the following error raised with sphinx 8.2.0

```
Versions
========

* Platform:         linux; (Linux-6.8.0-1021-azure-x86_64-with-glibc2.39)
* Python version:   3.12.9 (CPython)
* Sphinx version:   8.2.0
* Docutils version: 0.21.2
* Jinja2 version:   3.1.5
* Pygments version: 2.19.1

Last Messages
=============

    reference/api/skore.train_test_split


    reading sources... [ 91%]
    reference/index


    reading sources... [ 93%]
    reference/project

Loaded Extensions
=================

* sphinx.ext.mathjax (8.2.0)
* alabaster (1.0.0)
* sphinxcontrib.applehelp (2.0.0)
* sphinxcontrib.devhelp (2.0.0)
* sphinxcontrib.htmlhelp (2.1.0)
* sphinxcontrib.serializinghtml (2.0.0)
* sphinxcontrib.qthelp (2.0.0)
* sphinx.ext.autodoc.preserve_defaults (8.2.0)
* sphinx.ext.autodoc.type_comment (8.2.0)
* sphinx.ext.autodoc.typehints (8.2.0)
* sphinx.ext.autodoc (8.2.0)
* sphinx.ext.autosummary (8.2.0)
* numpydoc (1.8.0)
* sphinx.ext.githubpages (8.2.0)
* sphinx.ext.intersphinx (8.2.0)
* sphinx.ext.linkcode (8.2.0)
* sphinx_design (0.6.1)
* sphinx_gallery.gen_gallery (0.19.0)
* sphinx_copybutton (0.5.2)
* sphinx_tabs.tabs (unknown version)
* sphinx_autosummary_accessors (2023.4.0)
* pydata_sphinx_theme (unknown version)

Traceback
=========

      File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/sphinx/ext/autosummary/__init__.py", line 399, in get_items
        documenter = self.create_documenter(
                     ^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: create_documenter_from_template() got an unexpected keyword argument 'registry'


The full traceback has been saved in:
/tmp/sphinx-err-aordaedo.log

To report this error to the developers, please open an issue at <https://github.com/sphinx-doc/sphinx/issues/>. Thanks!
Please also report this if it was a user error, so that a better error message can be provided next time.
make: *** [Makefile:34: html] Error 2
```