### PR TITLE
Fix documentation of generic accessors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.12", "3.13"]
+        python-version: ["3.9", "3.12", "3.13", "3.14"]
         sphinx-version: ["5.3", "6.2", "7.3", "7.4", "8.0", "8.1", "8.2"]
         exclude:
           # sphinx>=8 requires at least python 3.10
@@ -32,18 +32,18 @@ jobs:
 
     steps:
       - name: checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: cache pip
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/pip
           key: pip-py${{ matrix.python-version }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2
           persist-credentials: false
@@ -44,21 +44,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.14"]
 
     outputs:
       artifacts_availability: ${{ steps.status.outputs.ARTIFACTS_AVAILABLE }}
 
     steps:
       - name: checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # need to fetch all tags to get a correct version
           fetch-depth: 0 # fetch all branches and tags
           persist-credentials: false
 
       - name: setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -106,14 +106,14 @@ jobs:
 
     steps:
       - name: checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           path: /tmp/workspace/logs
       - name: Move all log files into a single directory
@@ -125,7 +125,7 @@ jobs:
           shopt -s globstar
           python .github/workflows/format-report.py logs/**/*-log sphinx-log.txt
       - name: Report failures
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,9 +3,10 @@ version: 2
 formats: []
 
 build:
-  os: ubuntu-latest
+  os: ubuntu-lts-latest
   tools:
-    python: "3.14"
+    # just so RTD stops complaining
+    python: "latest"
   jobs:
     post_checkout:
       - (git --no-pager log --pretty="tformat:%s" -1 | grep -vqF "[skip-rtd]") || exit 183

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,9 +3,9 @@ version: 2
 formats: []
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-latest
   tools:
-    python: "3.12"
+    python: "3.14"
   jobs:
     post_checkout:
       - (git --no-pager log --pretty="tformat:%s" -1 | grep -vqF "[skip-rtd]") || exit 183

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 packaging
-sphinx>=6
+sphinx>=6,<9
 sphinx_rtd_theme

--- a/sphinx_autosummary_accessors/documenters.py
+++ b/sphinx_autosummary_accessors/documenters.py
@@ -1,3 +1,5 @@
+from typing import get_origin
+
 from sphinx.ext.autodoc import AttributeDocumenter, Documenter, MethodDocumenter
 from sphinx.ext.autodoc.importer import import_module
 
@@ -72,6 +74,14 @@ class AccessorDocumenter(AccessorLevelDocumenter, MethodDocumenter):
 
     # lower than MethodDocumenter so this is not chosen for normal methods
     priority = 0.6
+
+    def import_object(self, raiseerror=False):
+        imported = super().import_object(raiseerror)
+        if imported:
+            origin = get_origin(self.object)
+            if isinstance(origin, type):
+                self.object = origin
+        return imported
 
     def format_signature(self):
         # this method gives an error/warning for the accessors, therefore


### PR DESCRIPTION
- Python 3.14.7 added [a docstring](https://github.com/python/cpython/blob/v3.14.7/Lib/typing.py#L1318) to `typing._GenericAlias`. In Python 3.14.6 [they were code comments](https://github.com/python/cpython/blob/v3.14.6/Lib/typing.py#L1315). 
- This caused sphinx to parse the `_GenericAlias` docstring instead of the accessor and throw an error. 
- This PR updates the `import_object` method to unwrap the `StringAccessor`.
- This can be merged after xarray-contrib/sphinx-autosummary-accessors#173, or we can close #173 and target this to `main`